### PR TITLE
Fixed bug on UWP platform for method paste.

### DIFF
--- a/Clipboard/Plugin.Clipboard.Abstractions/IClipboard.cs
+++ b/Clipboard/Plugin.Clipboard.Abstractions/IClipboard.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Plugin.Clipboard.Abstractions
 {
@@ -17,6 +18,6 @@ namespace Plugin.Clipboard.Abstractions
         /// Gets the clipboard's text.
         /// </summary>
         /// <returns></returns>
-        string GetText();
+        Task<string> GetText();
   }
 }

--- a/Clipboard/Plugin.Clipboard.Android/ClipboardImplementation.cs
+++ b/Clipboard/Plugin.Clipboard.Android/ClipboardImplementation.cs
@@ -2,6 +2,7 @@ using Android.App;
 using Android.Content;
 using Plugin.Clipboard.Abstractions;
 using System;
+using System.Threading.Tasks;
 
 
 namespace Plugin.Clipboard
@@ -11,7 +12,12 @@ namespace Plugin.Clipboard
     /// </summary>
     public class ClipboardImplementation : IClipboard
     {
-        public string GetText()
+
+        public async Task<string> GetText()
+        {
+            return await Task.Run(() => GetClipboard());
+        }
+        public string GetClipboard()
         {
             var clipboardManager = (ClipboardManager) Application.Context.GetSystemService(Context.ClipboardService);
             return clipboardManager.Text;

--- a/Clipboard/Plugin.Clipboard.UWP/ClipboardImplementation.cs
+++ b/Clipboard/Plugin.Clipboard.UWP/ClipboardImplementation.cs
@@ -13,10 +13,15 @@ namespace Plugin.Clipboard
     /// </summary>
     public class ClipboardImplementation : IClipboard
     {
-        public string GetText()
+        public async Task<string> GetText()
         {
-            var dataPackage = Windows.ApplicationModel.DataTransfer.Clipboard.GetContent();
-            return dataPackage.GetTextAsync().GetResults();
+            DataPackageView dataPackageView = Windows.ApplicationModel.DataTransfer.Clipboard.GetContent();
+            if (dataPackageView.Contains(StandardDataFormats.Text))
+            {
+                string text = await dataPackageView.GetTextAsync();
+                return text;
+            }
+            return "";
         }
 
         public void SetText(string data)
@@ -25,5 +30,7 @@ namespace Plugin.Clipboard
             dataPackage.SetText(data);
             Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(dataPackage);
         }
+
+       
     }
 }

--- a/Clipboard/Plugin.Clipboard.iOS/ClipboardImplementation.cs
+++ b/Clipboard/Plugin.Clipboard.iOS/ClipboardImplementation.cs
@@ -1,6 +1,7 @@
 using Plugin.Clipboard.Abstractions;
 using System;
 using UIKit;
+using System.Threading.Tasks;
 
 namespace Plugin.Clipboard
 {
@@ -9,7 +10,12 @@ namespace Plugin.Clipboard
     /// </summary>
     public class ClipboardImplementation : IClipboard
     {
-        public string GetText()
+
+        public async Task<string> GetText()
+        {
+            return await Task.Run(() => GetClipboard());
+        }
+        public string GetClipboard()
         {
             UIPasteboard clipboard = UIPasteboard.General;
             return clipboard.String;
@@ -20,5 +26,7 @@ namespace Plugin.Clipboard
             UIPasteboard clipboard = UIPasteboard.General;
             clipboard.String = data;
         }
+
+       
     }
 }


### PR DESCRIPTION
On UWP platform it throws an exception. I've fixed this bug with another way to paste method.