### PR TITLE
Plugin.Clipboard.Gtk: fix project to use generic assemblyName

### DIFF
--- a/Clipboard/Nuget/Package.nuspec
+++ b/Clipboard/Nuget/Package.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Xamarin.Plugins.Clipboard</id>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <title>Xamarin Clipboard</title>
 	<authors>Stavros Kasidis (AkiraGTX)</authors>
     <owners>Stavros Kasidis (AkiraGTX)</owners>

--- a/Clipboard/Plugin.Clipboard.Gtk/Plugin.Clipboard.Gtk.csproj
+++ b/Clipboard/Plugin.Clipboard.Gtk/Plugin.Clipboard.Gtk.csproj
@@ -5,8 +5,8 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{38CB368D-5DEF-4471-944C-AD63A2DDDCF5}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>Plugin.Clipboard.Gtk</RootNamespace>
-    <AssemblyName>Plugin.Clipboard.Gtk</AssemblyName>
+    <RootNamespace>Plugin.Clipboard</RootNamespace>
+    <AssemblyName>Plugin.Clipboard</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Clipboard/Plugin.Clipboard/SharedAssemblyInfo.cs
+++ b/Clipboard/Plugin.Clipboard/SharedAssemblyInfo.cs
@@ -10,5 +10,5 @@
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.2.1.0")]
+[assembly: AssemblyFileVersion("2.2.1.0")]


### PR DESCRIPTION
This is to have consistency with other backend projects
and because if this is not fixed, a FileNotFoundException
would be thrown when trying to use the library from a
GTK# project.